### PR TITLE
Removed downloadable form link from iawa_terms.html file and adds it to "download" in .json file.

### DIFF
--- a/configs/html/iawa_terms.html
+++ b/configs/html/iawa_terms.html
@@ -1,5 +1,4 @@
 <h1>Conditions Governing Use of Materials from Special Collections for Publication</h1>
-<h3>Downloadable form: <a href='https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc'>doc</a></h3>
 <h3>Copyright Restrictions</h3>
 <p>The copyright law of the United States (Title 17, U.S. Code) governs the making of photocopies and other reproductions of copyrighted material. Libraries and archives are authorized to furnish reproductions upon request for specified purposes, including private study, scholarship, and research; publication; and public exhibition. This institution reserves the right to refuse to accept an order if, in its judgment, fulfillment of that order would involve violation of copyright law.</p>
 <h3>Publication or Public Exhibition Use</h3>

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -138,6 +138,7 @@
   },
   "termsCopy": {
     "type": "file",
-    "value": "html/iawa_terms.html"
+    "value": "html/iawa_terms.html",
+    "download": "https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc"
   }
 }


### PR DESCRIPTION
**Jira ticket**
https://webapps.es.vt.edu/jira/browse/LIBTD-2134

**What does this PR do**
It removes the downloadable form link from iawa_terms.html file and adds it to "download" in .json file.

**How to test**
When the next PR for iawa_v2 repo is pushed, this should allow the link to be pulled from the .json file and rendered onto the permissions page.

Branch: LIBTD-2134

**Interested parties**
@yinlinchen  
