### PR TITLE
Added data for default static image

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -25,6 +25,10 @@
     }
   ],
   "homePage": {
+    "staticImage": {
+      "src": "images/static/default.jpg",
+      "altText": ""
+    },
     "carousel": [
       {
         "src": "images/carousel/2_Ms2008_089_B001_F007_001_SecondSt_Ms_001_r.jpg",


### PR DESCRIPTION
Jira ticket: https://webapps.es.vt.edu/jira/browse/LIBTD-2170

What does this PR do?
It adds the data needed to load a default static image for the default config file.

How to test?
Once the PR for the iawa_v2 is merged, a grey background will be loaded behind the site title.

Interested parties:
@yinlinchen 