### PR TITLE
Adds sponsors section data

### DIFF
--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -103,7 +103,19 @@
         "link": "/archive/c3820r21"
       }
     ],
-    "statement": "A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries at Virginia Tech"
+    "statement": "A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries at Virginia Tech",
+    "sponsors": [
+      {
+        "img": "/images/sponsors/CLIR_red_w_wordmark.png",
+        "alt": "Council on Library and Information Resources",
+        "link": "https://www.clir.org/"
+      },
+      {
+        "img": "/images/sponsors/iawa_logo.png",
+        "alt": "IAWA",
+        "link": "https://spec.lib.vt.edu/iawa/"
+      }
+    ]
   },
   "contact": [
     {


### PR DESCRIPTION
Jira ticket: https://webapps.es.vt.edu/jira/browse/LIBTD-2215

What does the PR do?
This PR adds the necessary data for the sponsors section to the IAWA config file.

How to test?
Once I open the pull request for the updated code on the iawa_v2 repo, then the sponsors section should be populated.

Interested parties:
@yinlinchen 