### PR TITLE
Adds highlight color for IAWA site

### DIFF
--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -2,6 +2,7 @@
   "siteId": "iawa",
   "siteTitle": "IAWA",
   "siteName": "International Archive of Women in Architecture",
+  "siteColor": "#c52a1d",
   "siteNavLinks": [
     {
       "text": "Home",


### PR DESCRIPTION
Jira ticket:
https://webapps.es.vt.edu/jira/browse/LIBTD-2219

What does it do?
This PR adds the necessary data to allow the highlight color for IAWA to be set to their branded color. Other collections will default to VT maroon.

How to test?
When the next PR on the iawa_v2 repo is made, this will cause all highlight areas in IAWA to be red and highlight areas in SWVA will be maroon.

Interested parties:
@yinlinchen  