### PR TITLE
Updated links for featured items to the correct link for production site

### DIFF
--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -35,73 +35,73 @@
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/3_Church_r.jpg",
         "altText": "Melita Rodeck's Altar, church interior",
         "cardTitle": "Altar, church interior, n.d. Elevation (Ms1992-028)",
-        "link": "/archive/4610h699"
+        "link": "https://iawa.lib.vt.edu/archive/4610h699"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1988-017_F003_003_Peck_Ph_001.jpg",
         "altText": "Alberta Pfeiffer's Living room, Peck residence",
         "cardTitle": "Living room, Peck residence, Hadlyme, Connecticut, n.d. Photograph (Ms1988-017)",
-        "link": "/archive/0z63vz4c"
+        "link": "https://iawa.lib.vt.edu/archive/0z63vz4c"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1990_025_EconLab_Dr_F002_019_001.jpg",
         "altText": "Lorraine Rudoff's Economics Laboratory Inc.",
         "cardTitle": "Economics Laboratory Inc., Industry, California, October 31, 1975. Framing plan and sections (Ms1990-025)",
-        "link": "/archive/kr10gt01"
+        "link": "https://iawa.lib.vt.edu/archive/kr10gt01"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms2013_088_B010_037_BeverlyGlenApartments_Bp.jpg",
         "altText": "Margaret Ann Cochrane's Beverly Glen Apartments",
         "cardTitle": "Beverly Glen Apartments, December 20, 1972. Index of drawings (Ms2013-088)",
-        "link": "/archive/8x13502w"
+        "link": "https://iawa.lib.vt.edu/archive/8x13502w"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1992_028_B002_F001_Dunbarton_Dr_003_001.jpg",
         "altText": "Melita Rodeck's Proposed dormitory building",
         "cardTitle": "Proposed dormitory building, Dunbarton College, Washington, D.C., n.d. Elevation (Ms1992-028)",
-        "link": "/archive/t7697v1n"
+        "link": "https://iawa.lib.vt.edu/archive/t7697v1n"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1994_016_F004_Per_Art_011_001.jpg",
         "altText": "Martha J. Crawford's Jazz Waltz, Good News Blues",
         "cardTitle": "Jazz Waltz, Good News Blues [Shapes on a peach background], n.d. Pastel (Ms1994-016)",
-        "link": "/archive/sw51r726"
+        "link": "https://iawa.lib.vt.edu/archive/sw51r726"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms2007_009_F003_Untitled_Dr_001_001.jpg",
         "altText": "E. Maria Roth's [Street and trees]",
         "cardTitle": "[Street and trees], n.d. Sketch (Ms2007-009)",
-        "link": "/archive/xp10cq71"
+        "link": "https://iawa.lib.vt.edu/archive/xp10cq71"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1990_057_F002_006_Per_Dr_001.jpg",
         "altText": "Olive Chadeayne's Private Chapel",
         "cardTitle": "Private chapel, c. 1925. Floor plan (Ms1990-057)",
-        "link": "/archive/gg29pm16"
+        "link": "https://iawa.lib.vt.edu/archive/gg29pm16"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1998_022_B002_F010_001_Pro_Ms_001.jpg",
         "altText": "Jean Linden Young's Materials related to the l'Union Internationale des Femmes Architects",
         "cardTitle": "Materials related to the l'Union Internationale des Femmes Architects (International Association of Women Architects) meeting, Ramsar, Iran, June 15, 1976-October 30, 1976. Photographs and documents (Ms1998-022)",
-        "link": "/archive/kj57dm1n"
+        "link": "https://iawa.lib.vt.edu/archive/kj57dm1n"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms2007_009_B001_F014_Per_Ms_001_001.jpg",
         "altText": "E. Maria Roth's Press Coverage",
         "cardTitle": "Press Coverage, c. 1975-1976. Clippings (Ms2007-009)",
-        "link": "/archive/0798vb7h"
+        "link": "https://iawa.lib.vt.edu/archive/0798vb7h"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms2013_023_B001_F004_001_Per_Ph_001.jpg",
         "altText": "Dorothee S. King",
         "cardTitle": "Dorothee S. King, c. 1980. Photograph",
-        "link": "/archive/1n317994"
+        "link": "https://iawa.lib.vt.edu/archive/1n317994"
       },
       {
         "src": "https://vtdlp-dev-site-data.s3.amazonaws.com/images/iawa/Ms1998_022_B003_F002_005_Pro_Ph_001.jpg",
         "altText": "Jean Linden Young' Bakery shop",
         "cardTitle": "Bakery shop, exhibition board, Lexington, Kentucky, n.d. Photograph (Ms1998-022)",
-        "link": "/archive/dt88zr74"
+        "link": "https://iawa.lib.vt.edu/archive/dt88zr74"
       }
     ],
     "statement": "A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries at Virginia Tech",


### PR DESCRIPTION
Jira ticket:
https://webapps.es.vt.edu/jira/browse/LIBTD-2229

What does this PR do?
The configuration for the featured itesms component was originally set up using the permanet links to the items in the dev site. Since all items are renumbered in the production site, this PR updates the links for each featured item to the correct link for production site.

Interested parties:
@yinlinchen 