### PR TITLE
Add content to podcasts config file

### DIFF
--- a/configs/podcasts.json
+++ b/configs/podcasts.json
@@ -1,6 +1,6 @@
 {
   "siteId": "podcasts",
-  "siteTitle": "Podcasts",
+  "siteTitle": "Podcasts from Virginia Tech Publishing",
   "siteName": "Podcasts from Virginia Tech Publishing",
   "analyticsID": "podcasts",
   "siteNavLinks": [
@@ -29,17 +29,29 @@
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/default/default.jpg",
       "altText": ""
+    },
+    "homeStatement": {
+      "statement": "The Virginia Tech Publishing podcast initiative in the University Libraries is a program aimed at building a media production community of scholars exploring multi-modal publication across a broad spectrum of disciplines. The program also supports members of the Virginia Tech community interested in publishing cultural commentary to be held within digital collections in the Libraries. The Libraries provide access below to all shows produced by VT podcasters and also make those widely available across popular podcasting platforms."
     }
   },
   "contact": [
     {
       "title": "Virginia Tech Publishing",
-      "email": "",
+      "email": "publishing@vt.edu",
       "group": "",
       "department": "Virginia Tech Publishing",
       "streetAddress": "560 Drillfield Drive",
       "cityStateZip": "Blacksburg, VA 24061",
       "phone": ""
+    },
+    {
+      "title": "Athenaeum",
+      "email": "athenaeum@vt.edu",
+      "group": "University Libraries",
+      "department": "Newman Library",
+      "streetAddress": "560 Drillfield Drive",
+      "cityStateZip": "Blacksburg, VA 24061",
+      "phone": "540-231-6737"
     }
   ],
   "aboutCopy": {
@@ -65,9 +77,7 @@
         "label": "Type",
         "name": "resource_type",
         "multiValued": true,
-        "values": ["image",
-                   "Posters"
-        ]
+        "values": ["image", "Posters"]
       }
     ]
   }


### PR DESCRIPTION
Jira: https://webapps.es.vt.edu/jira/browse/LIBTD-2262

What does this do?
Adds content to podcasts config file

What does it change?
The stakeholders have only provided a homepage statement and contact info, so far. I also changed the site title to match the site name since we don't really have an abbreviated title for this collection, like we do with IAWA and SWVA.

How to test?
The homepage statement and contact info on the about/terms pages should populate.

Interested parties?
@yinlinchen 