### PR TITLE
Added showTitle property to each config file

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -28,7 +28,8 @@
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/default/default.jpg",
-      "altText": ""
+      "altText": "",
+      "showTitle": true
     },
     "sponsors": [
       {

--- a/configs/hokies.json
+++ b/configs/hokies.json
@@ -28,7 +28,8 @@
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/hokies/HokiesatHomeCover.jpg",
-      "altText": "A woman wearing headphones sits in front of a home office desk with a small dog in her lap."
+      "altText": "A woman wearing headphones sits in front of a home office desk with a small dog in her lap.",
+      "showTitle": true
     },
     "homeStatement": {
       "heading": "Documenting COVID-19 at Virginia Tech",

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -29,7 +29,8 @@
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/iawa_Ms1994_016_F004_Per_Art_005_001.jpg",
-      "altText": "[Modern-style living room in grayscale], n.d. Watercolor (Ms1994-016)"
+      "altText": "[Modern-style living room in grayscale], n.d. Watercolor (Ms1994-016)",
+      "showTitle": true
     },
     "featuredItems": [
       {

--- a/configs/podcasts.json
+++ b/configs/podcasts.json
@@ -27,8 +27,9 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/default/default.jpg",
-      "altText": ""
+      "src": "https://img.cloud.lib.vt.edu/sites/images/podcasts/Podcasts_DLP.png",
+      "altText": "Virginia Tech Publishing Podcasts",
+      "showTitle": false
     },
     "homeStatement": {
       "statement": "The Virginia Tech Publishing podcast initiative in the University Libraries is a program aimed at building a media production community of scholars exploring multi-modal publication across a broad spectrum of disciplines. The program also supports members of the Virginia Tech community interested in publishing cultural commentary to be held within digital collections in the Libraries. The Libraries provide access below to all shows produced by VT podcasters and also make those widely available across popular podcasting platforms."

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -28,7 +28,8 @@
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/swva/market_scene2.jpg",
-      "altText": "Market Scene, Johan Hamza (Austrian, 1850-1927)"
+      "altText": "Market Scene, Johan Hamza (Austrian, 1850-1927)",
+      "showTitle": true
     },
     "homeStatement": {
       "statement": "The Southwest Virginia Digital Archive is an online library for the arts, sciences, culture, and history of Appalachia, and the Commonwealth of Virginia. Virginia Tech University Libraries partners with regional stakeholders to digitize, preserve, and provide access to digital assets from across the region. Unless stated otherwise, all original materials and intellectual property belong to the contributing institution and are provided here for free educational use to the public."


### PR DESCRIPTION
Jira ticket: https://webapps.es.vt.edu/jira/browse/LIBTD-2278

What does this PR do?
Adds a showTitle property to each staticImage which will allow the title text overlay on the cover image to be configurable.

How to test?
When my next PR for dlp-access repo is made, this should allow the podcasts library to show just a cover image on the home page with no text overlay, while all the other libraries will still show a cover image with the library title as a text overlay.

branch is LIBTD-2278

interested parties:
@yinlinchen 