### PR TITLE
updated image file names to standard names

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -27,28 +27,28 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/default/default.jpg",
+      "src": "https://img.cloud.lib.vt.edu/sites/images/default/cover_image.jpg",
       "altText": "",
       "showTitle": true
     },
     "sponsors": [
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/default/CLIR_red_w_wordmark.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/default/sponsor1.png",
         "alt": "CLIR",
         "link": "https://www.clir.org/"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/default/iawa_logo.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/default/sponsor2.png",
         "alt": "IAWA",
         "link": "https://spec.lib.vt.edu/iawa/"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/default/library-logo-lockup_color.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/default/sponsor3.png",
         "alt": "Virginia Tech Libraries",
         "link": "https://lib.vt.edu/"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/default/vt_logo.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/default/sponsor4.png",
         "alt": "Virginia Tech",
         "link": "https://vt.edu/"
       }

--- a/configs/hokies.json
+++ b/configs/hokies.json
@@ -27,7 +27,7 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/hokies/HokiesatHomeCover.jpg",
+      "src": "https://img.cloud.lib.vt.edu/sites/images/hokies/cover_image.jpg",
       "altText": "A woman wearing headphones sits in front of a home office desk with a small dog in her lap.",
       "showTitle": true
     },
@@ -37,7 +37,7 @@
     },
     "sponsors": [
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/hokies/VT-Libraries-Logo-Vertical_White.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/hokies/sponsor1.png",
         "alt": "University Libraries at Virginia Tech",
         "link": "https://lib.vt.edu/"
       }

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -28,79 +28,79 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/iawa_Ms1994_016_F004_Per_Art_005_001.jpg",
+      "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/cover_image.jpg",
       "altText": "[Modern-style living room in grayscale], n.d. Watercolor (Ms1994-016)",
       "showTitle": true
     },
     "featuredItems": [
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/3_Church_r.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item1.jpg",
         "altText": "Melita Rodeck's Altar, church interior",
         "cardTitle": "Altar, church interior, n.d. Elevation (Ms1992-028)",
         "link": "https://iawa.lib.vt.edu/archive/4610h699"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1988-017_F003_003_Peck_Ph_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item2.jpg",
         "altText": "Alberta Pfeiffer's Living room, Peck residence",
         "cardTitle": "Living room, Peck residence, Hadlyme, Connecticut, n.d. Photograph (Ms1988-017)",
         "link": "https://iawa.lib.vt.edu/archive/0z63vz4c"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1990_025_EconLab_Dr_F002_019_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item3.jpg",
         "altText": "Lorraine Rudoff's Economics Laboratory Inc.",
         "cardTitle": "Economics Laboratory Inc., Industry, California, October 31, 1975. Framing plan and sections (Ms1990-025)",
         "link": "https://iawa.lib.vt.edu/archive/kr10gt01"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms2013_088_B010_037_BeverlyGlenApartments_Bp.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item4.jpg",
         "altText": "Margaret Ann Cochrane's Beverly Glen Apartments",
         "cardTitle": "Beverly Glen Apartments, December 20, 1972. Index of drawings (Ms2013-088)",
         "link": "https://iawa.lib.vt.edu/archive/8x13502w"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1992_028_B002_F001_Dunbarton_Dr_003_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item5.jpg",
         "altText": "Melita Rodeck's Proposed dormitory building",
         "cardTitle": "Proposed dormitory building, Dunbarton College, Washington, D.C., n.d. Elevation (Ms1992-028)",
         "link": "https://iawa.lib.vt.edu/archive/t7697v1n"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1994_016_F004_Per_Art_011_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item6.jpg",
         "altText": "Martha J. Crawford's Jazz Waltz, Good News Blues",
         "cardTitle": "Jazz Waltz, Good News Blues [Shapes on a peach background], n.d. Pastel (Ms1994-016)",
         "link": "https://iawa.lib.vt.edu/archive/sw51r726"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms2007_009_F003_Untitled_Dr_001_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item7.jpg",
         "altText": "E. Maria Roth's [Street and trees]",
         "cardTitle": "[Street and trees], n.d. Sketch (Ms2007-009)",
         "link": "https://iawa.lib.vt.edu/archive/xp10cq71"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1990_057_F002_006_Per_Dr_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item8.jpg",
         "altText": "Olive Chadeayne's Private Chapel",
         "cardTitle": "Private chapel, c. 1925. Floor plan (Ms1990-057)",
         "link": "https://iawa.lib.vt.edu/archive/gg29pm16"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1998_022_B002_F010_001_Pro_Ms_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item9.jpg",
         "altText": "Jean Linden Young's Materials related to the l'Union Internationale des Femmes Architects",
         "cardTitle": "Materials related to the l'Union Internationale des Femmes Architects (International Association of Women Architects) meeting, Ramsar, Iran, June 15, 1976-October 30, 1976. Photographs and documents (Ms1998-022)",
         "link": "https://iawa.lib.vt.edu/archive/kj57dm1n"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms2007_009_B001_F014_Per_Ms_001_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item10.jpg",
         "altText": "E. Maria Roth's Press Coverage",
         "cardTitle": "Press Coverage, c. 1975-1976. Clippings (Ms2007-009)",
         "link": "https://iawa.lib.vt.edu/archive/0798vb7h"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms2013_023_B001_F004_001_Per_Ph_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item11.jpg",
         "altText": "Dorothee S. King",
         "cardTitle": "Dorothee S. King, c. 1980. Photograph",
         "link": "https://iawa.lib.vt.edu/archive/1n317994"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1998_022_B003_F002_005_Pro_Ph_001.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/featured_item12.jpg",
         "altText": "Jean Linden Young' Bakery shop",
         "cardTitle": "Bakery shop, exhibition board, Lexington, Kentucky, n.d. Photograph (Ms1998-022)",
         "link": "https://iawa.lib.vt.edu/archive/dt88zr74"
@@ -112,37 +112,37 @@
     },
     "sponsors": [
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/CLIR_red_w_wordmark.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/sponsor1.png",
         "alt": "Council on Library and Information Resources",
         "link": "https://www.clir.org/"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/iawa_logo.png",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/sponsor2.png",
         "alt": "IAWA",
         "link": "https://spec.lib.vt.edu/iawa/"
       }
     ],
     "collectionHighlights": [
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1994_016_F002_Per_Art_016_001.jpg",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/highlight1.jpg",
         "title": "Travel sketches by IAWA architects",
         "link": "/search?q=&field=description&view=Gallery&category=archive&resource_type=Travel+sketches",
         "itemCount": "51"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1990_025_Per_Scrap_B001_F002_001_001.jpg",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/highlight2.jpg",
         "title": "Educational and Research Facilities",
         "link": "/search/?category=archive&field=tags&q=Educational%20and%20research&view=Gallery",
         "itemCount": "294"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms2013_023_F003_022_Austellungbau_Dr_001.jpg",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/highlight3.jpg",
         "title": "Student work by IAWA architects",
         "link": "/search/?category=archive&field=tags&q=Student%20work&view=Gallery",
         "itemCount": "85"
       },
       {
-        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/Ms1992_028_F027_001_AABhangar_Bp_001.jpg",
+        "img": "https://img.cloud.lib.vt.edu/sites/images/iawa/highlight4.jpg",
         "title": "Axonometric projections",
         "link": "/search/?q=&field=description&view=Gallery&resource_type=Axonometric+projections+%28images%29",
         "itemCount": "7"

--- a/configs/podcasts.json
+++ b/configs/podcasts.json
@@ -27,7 +27,7 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/podcasts/Podcasts_DLP.png",
+      "src": "https://img.cloud.lib.vt.edu/sites/images/podcasts/cover_image.png",
       "altText": "Virginia Tech Publishing Podcasts",
       "showTitle": false
     },

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -27,7 +27,7 @@
   ],
   "homePage": {
     "staticImage": {
-      "src": "https://img.cloud.lib.vt.edu/sites/images/swva/market_scene2.jpg",
+      "src": "https://img.cloud.lib.vt.edu/sites/images/swva/cover_image.jpg",
       "altText": "Market Scene, Johan Hamza (Austrian, 1850-1927)",
       "showTitle": true
     },
@@ -36,55 +36,55 @@
     },
     "featuredItems": [
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/TAU_ART_000122_0004_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item1.jpg",
         "altText": "Piper, Robert Ryland Kearfott (American, 1890-1969)",
         "cardTitle": "Piper",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/j5081t6w"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/TAU_ART_000123_0002_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item2.jpg",
         "altText": "Portrait of Norah Gribble, John Singer Sargent (American, 1856-1925)",
         "cardTitle": "Portrait of Norah Gribble",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/dq15ch4x"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/TAU_ART_000130_0006_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item3.jpg",
         "altText": "Curtsey, E. Antoinette Hale (American, Contemporary)",
         "cardTitle": "Curtsey",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/d464fm8m"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/market_scene.JPG",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item4.JPG",
         "altText": "Market Scene, Johan Hamza (Austrian, 1850-1927)",
         "cardTitle": "Market Scene",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/kx75vp3q"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/shackled.JPG",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item5.JPG",
         "altText": "Shackled Hands And Human Chains, Purvis Young (American, 1943-2010)",
         "cardTitle": "Shackled Hands And Human Chains",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/6p15t97g"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/BTR_BTR_000475_0001_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item6.jpg",
         "altText": "Thieves Carnival, Barter Theatre",
         "cardTitle": "Thieves Carnival",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/2k14bg2z"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/BTR_BTR_000218_0001_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item7.jpg",
         "altText": "Leader of the Pack by Sherman Ewing, Barter Theatre",
         "cardTitle": "Leader of the Pack by Sherman Ewing",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/8g08sz6b"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/BTR_BTR_000640_0001_acs.jpg",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item8.jpg",
         "altText": "As You Like It by William Shakespeare, Barter Theatre",
         "cardTitle": "As You Like It by William Shakespeare",
         "link": "https://swva-dev.cloud.lib.vt.edu/archive/0c595666"
       },
       {
-        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/measure.JPG",
+        "src": "https://img.cloud.lib.vt.edu/sites/images/swva/featured_item9.JPG",
         "altText": "Measure For Measure by William Shakespeare, Virginia Polytechnic Institute and State University. Theatre Arts - University Theatre",
         "cardTitle": "Measure For Measure by William Shakespeare",
         "link": ""


### PR DESCRIPTION
https://webapps.es.vt.edu/jira/browse/LIBTD-2279

What does this PR do?
updated the filenames for images in each DLP config file to the standard name for that image.

How to test?
once my other PR (https://github.com/VTUL/VTDLP-sitecontent/pull/3) is merged, then all the images (cover image, featured items, sponsors and collection highlights) should show up on the home page as they did before.

Branch is LIBTD-2279

interested parties:
@yinlinchen 