### PR TITLE
refactor siteNavLinks to sitePages object

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -4,28 +4,14 @@
   "siteName": "Virginia Tech Digital Library Platform",
   "analyticsID": "example",
   "assetBasePath": "https://img.cloud.lib.vt.edu/sites/html/default",
-  "siteNavLinks": [
-    {
-      "text": "Home",
-      "url": "/"
-    },
-    {
+  "sitePages": {
+    "about": {
       "text": "About",
-      "url": "/about"
-    },
-    {
-      "text": "Permission Page",
-      "url": "/terms"
-    },
-    {
-      "text": "Browse Collections",
-      "url": "/collections"
-    },
-    {
-      "text": "Search Items",
-      "url": "/search"
+      "local_url": "/about",
+      "data_url": "default_about.html",
+      "component": "AboutPage"
     }
-  ],
+  },
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/default/cover_image.jpg",
@@ -73,11 +59,6 @@
       "phone": "(540)231-6170"
     }
   ],
-  "aboutCopy": {
-    "type": "file",
-    "value": "default_about.html"
-  },
-  "termsCopy": {},
   "searchPage": {
     "facets": [
       {

--- a/configs/hokies.json
+++ b/configs/hokies.json
@@ -4,28 +4,20 @@
   "siteName": "Hokies@Home",
   "analyticsID": "hokies",
   "assetBasePath": "https://img.cloud.lib.vt.edu/sites/html/hokies",
-  "siteNavLinks": [
-    {
-      "text": "Home",
-      "url": "/"
-    },
-    {
+  "sitePages": {
+    "about": {
       "text": "About",
-      "url": "/about"
+      "local_url": "/about",
+      "data_url": "hokies_about.html",
+      "component": "AboutPage"
     },
-    {
-      "text": "Permission Page",
-      "url": "/terms"
-    },
-    {
-      "text": "Browse Collections",
-      "url": "/collections"
-    },
-    {
-      "text": "Search Items",
-      "url": "/search"
+    "terms": {
+      "text": "Permissions",
+      "local_url": "/permissions",
+      "data_url": "hokies_terms.html",
+      "component": "PermissionsPage"
     }
-  ],
+  },
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/hokies/cover_image.jpg",
@@ -55,14 +47,6 @@
       "phone": "(540) 231-4442"
     }
   ],
-  "aboutCopy": {
-    "type": "file",
-    "value": "hokies_about.html"
-  },
-  "termsCopy": {
-    "type": "file",
-    "value": "hokies_terms.html"
-  },
   "searchPage": {
     "facets": [
       {

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -5,28 +5,23 @@
   "siteColor": "#c52a1d",
   "analyticsID": "UA-4094890-21",
   "assetBasePath": "https://img.cloud.lib.vt.edu/sites/html/iawa",
-  "siteNavLinks": [
-    {
-      "text": "Home",
-      "url": "/"
-    },
-    {
+  "sitePages": {
+    "about": {
       "text": "About",
-      "url": "/about"
+      "local_url": "/about",
+      "data_url": "iawa_about.html",
+      "component": "AboutPage"
     },
-    {
-      "text": "Permission Page",
-      "url": "/terms"
-    },
-    {
-      "text": "Browse Collections",
-      "url": "/collections"
-    },
-    {
-      "text": "Search Items",
-      "url": "/search"
+    "terms": {
+      "text": "Permissions",
+      "local_url": "/permissions",
+      "data_url": "iawa_terms.html",
+      "component": "PermissionsPage",
+      "assets": {
+        "download": "https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc"
+      }
     }
-  ],
+  },
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/iawa/cover_image.jpg",
@@ -170,15 +165,6 @@
       "phone": "(540)231-5512"
     }
   ],
-  "aboutCopy": {
-    "type": "file",
-    "value": "iawa_about.html"
-  },
-  "termsCopy": {
-    "type": "file",
-    "value": "iawa_terms.html",
-    "download": "https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc"
-  },
   "searchPage": {
     "facets": [
       {

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -4,28 +4,58 @@
   "siteName": "Southwest Virginia Digital Archive",
   "analyticsID": "example",
   "assetBasePath": "https://img.cloud.lib.vt.edu/sites/html/swva",
-  "siteNavLinks": [
-    {
-      "text": "Home",
-      "url": "/"
-    },
-    {
+  "sitePages": {
+    "about": {
       "text": "About",
-      "url": "/about"
-    },
-    {
-      "text": "Permission Page",
-      "url": "/terms"
-    },
-    {
-      "text": "Browse Collections",
-      "url": "/collections"
-    },
-    {
-      "text": "Search Items",
-      "url": "/search"
+      "local_url": "/about",
+      "data_url": "swva_about.html",
+      "component": "AboutPage",
+      "children": {
+        "communityCatalysts": {
+          "text": "Community Catalysts",
+          "local_url": "/community-catalysts",
+          "component": "AdditionalPages",
+          "data_url": "swva_community-catalysts.html"
+        },
+        "digitalPreservation": {
+          "text": "Digital Preservation",
+          "local_url": "/digital-preservation",
+          "component": "AdditionalPages",
+          "data_url": "swva_digital-preservation.html"
+        },
+        "getInvolved": {
+          "text": "Get Involved",
+          "local_url": "/get-involved",
+          "component": "AdditionalPages",
+          "data_url": "swva_get-involved.html"
+        },
+        "imaging": {
+          "text": "Imaging",
+          "local_url": "/imaging",
+          "component": "AdditionalPages",
+          "data_url": "swva_imaging.html"
+        },
+        "metadata": {
+          "text": "Metadata",
+          "local_url": "/metadata",
+          "component": "AdditionalPages",
+          "data_url": "swva_metadata.html"
+        },
+        "partners": {
+          "text": "Partners",
+          "local_url": "/partners",
+          "component": "AdditionalPages",
+          "data_url": "swva_partners.html"
+        },
+        "people": {
+          "text": "People",
+          "local_url": "/people",
+          "component": "AdditionalPages",
+          "data_url": "swva_people.html"
+        }
+      }
     }
-  ],
+  },
   "homePage": {
     "staticImage": {
       "src": "https://img.cloud.lib.vt.edu/sites/images/swva/cover_image.jpg",
@@ -103,55 +133,6 @@
       "phone": "(540)553-2845"
     }
   ],
-  "aboutCopy": {
-    "type": "file",
-    "value": "swva_about.html",
-    "additionalPages": [
-      {
-        "title": "Community Development Model",
-        "link": "/community-catalysts",
-        "type": "file",
-        "value": "swva_community-catalysts.html"
-      },
-      {
-        "title": "Digital Preservation",
-        "link": "/digital-preservation",
-        "type": "file",
-        "value": "swva_digital-preservation.html"
-      },
-      {
-        "title": "Get Involved",
-        "link": "/get-involved",
-        "type": "file",
-        "value": "swva_get-involved.html"
-      },
-      {
-        "title": "Imaging",
-        "link": "/imaging",
-        "type": "file",
-        "value": "swva_imaging.html"
-      },
-      {
-        "title": "Metadata",
-        "link": "/metadata",
-        "type": "file",
-        "value": "swva_metadata.html"
-      },
-      {
-        "title": "Partners",
-        "link": "/partners",
-        "type": "file",
-        "value": "swva_partners.html"
-      },
-      {
-        "title": "People",
-        "link": "/people",
-        "type": "file",
-        "value": "swva_people.html"
-      }
-    ]
-  },
-  "termsCopy": {},
   "searchPage": {
     "facets": [
       {


### PR DESCRIPTION
This PR changes the format of the site config json files from the siteNavLinks ARRAY to a sitePages OBJECT. This is done to support the changes in `LIBTD-2282`

@yinlinchen 