### PR TITLE
Updated html file names

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -8,7 +8,7 @@
     "about": {
       "text": "About",
       "local_url": "/about",
-      "data_url": "default_about.html",
+      "data_url": "about.html",
       "component": "AboutPage"
     }
   },

--- a/configs/hokies.json
+++ b/configs/hokies.json
@@ -8,13 +8,13 @@
     "about": {
       "text": "About",
       "local_url": "/about",
-      "data_url": "hokies_about.html",
+      "data_url": "about.html",
       "component": "AboutPage"
     },
     "terms": {
       "text": "Permissions",
       "local_url": "/permissions",
-      "data_url": "hokies_terms.html",
+      "data_url": "terms.html",
       "component": "PermissionsPage"
     }
   },

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -9,13 +9,13 @@
     "about": {
       "text": "About",
       "local_url": "/about",
-      "data_url": "iawa_about.html",
+      "data_url": "about.html",
       "component": "AboutPage"
     },
     "terms": {
       "text": "Permissions",
       "local_url": "/permissions",
-      "data_url": "iawa_terms.html",
+      "data_url": "terms.html",
       "component": "PermissionsPage",
       "assets": {
         "download": "https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc"

--- a/configs/podcasts.json
+++ b/configs/podcasts.json
@@ -7,13 +7,13 @@
     "about": {
       "text": "About",
       "local_url": "/about",
-      "data_url": "html/default_about.html",
+      "data_url": "html/default/about.html",
       "component": "AboutPage"
     },
     "terms": {
       "text": "Permissions",
       "local_url": "/permissions",
-      "data_url": "iawa_terms.html",
+      "data_url": "html/iawa/terms.html",
       "component": "PermissionsPage",
       "assets": {
         "download": "https://digitalsc.lib.vt.edu/files/thumbnails/spec_forms/PubPermission.doc"

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -8,50 +8,50 @@
     "about": {
       "text": "About",
       "local_url": "/about",
-      "data_url": "swva_about.html",
+      "data_url": "about.html",
       "component": "AboutPage",
       "children": {
         "communityCatalysts": {
           "text": "Community Catalysts",
           "local_url": "/community-catalysts",
           "component": "AdditionalPages",
-          "data_url": "swva_community-catalysts.html"
+          "data_url": "community-catalysts.html"
         },
         "digitalPreservation": {
           "text": "Digital Preservation",
           "local_url": "/digital-preservation",
           "component": "AdditionalPages",
-          "data_url": "swva_digital-preservation.html"
+          "data_url": "digital-preservation.html"
         },
         "getInvolved": {
           "text": "Get Involved",
           "local_url": "/get-involved",
           "component": "AdditionalPages",
-          "data_url": "swva_get-involved.html"
+          "data_url": "get-involved.html"
         },
         "imaging": {
           "text": "Imaging",
           "local_url": "/imaging",
           "component": "AdditionalPages",
-          "data_url": "swva_imaging.html"
+          "data_url": "imaging.html"
         },
         "metadata": {
           "text": "Metadata",
           "local_url": "/metadata",
           "component": "AdditionalPages",
-          "data_url": "swva_metadata.html"
+          "data_url": "metadata.html"
         },
         "partners": {
           "text": "Partners",
           "local_url": "/partners",
           "component": "AdditionalPages",
-          "data_url": "swva_partners.html"
+          "data_url": "partners.html"
         },
         "people": {
           "text": "People",
           "local_url": "/people",
           "component": "AdditionalPages",
-          "data_url": "swva_people.html"
+          "data_url": "people.html"
         }
       }
     }


### PR DESCRIPTION
Jira ticket: https://webapps.es.vt.edu/jira/browse/LIBTD-2288

What does this PR do? Updates the html file names in the config files to match the new names in PR https://github.com/VTUL/VTDLP-sitecontent/pull/5

How to test? Once this PR and the other PR are merged, the html content should continue to pull from the files as usual.

Interested parties:
@yinlinchen 