### PR TITLE
LIBTD-2311: Add metadata display configurations

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -99,5 +99,139 @@
         "direction": "desc"
       }
     ]
+  },
+  "displayedAttributes": {
+    "collection": [
+      {
+        "field": "size",
+        "label": "Size"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "date",
+        "label": "Date"
+      },
+      {
+        "field": "subject",
+        "label": "Subject"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "related_url",
+        "label": "Related URL"
+      },
+      {
+        "field": "provenance",
+        "label": "Provenance"
+      },
+      {
+        "field": "belongs_to",
+        "label": "Belongs to"
+      }
+    ],
+    "archive": [
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "belongs_to",
+        "label": "Belongs to"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "contributor",
+        "label": "Contributor"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "custom_key",
+        "label": "Permanent Link"
+      },
+      {
+        "field": "format",
+        "label": "Format"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "location",
+        "label": "Location"
+      },
+      {
+        "field": "medium",
+        "label": "Medium"
+      },
+      {
+        "field": "resource_type",
+        "label": "Type"
+      },
+      {
+        "field": "related_url",
+        "label": "Related URL"
+      },
+      {
+        "field": "provenance",
+        "label": "Provenance"
+      },
+      {
+        "field": "repository",
+        "label": "Repository"
+      },
+      {
+        "field": "reference",
+        "label": "References"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "source",
+        "label": "Source"
+      },
+      {
+        "field": "start_date",
+        "label": "Date"
+      },
+      {
+        "field": "tags",
+        "label": "Tags"
+      }
+    ]
   }
 }

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -362,5 +362,115 @@
         "direction": "desc"
       }
     ]
+  },
+  "displayedAttributes": {
+    "collection": [
+      {
+        "field": "size",
+        "label": "Size"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "date",
+        "label": "Date"
+      },
+      {
+        "field": "subject",
+        "label": "Subject"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "related_url",
+        "label": "Related URL"
+      }
+    ],
+    "archive": [
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "belongs_to",
+        "label": "Belongs to"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "custom_key",
+        "label": "Permanent Link"
+      },
+      {
+        "field": "format",
+        "label": "Format"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "location",
+        "label": "Location"
+      },
+      {
+        "field": "medium",
+        "label": "Medium"
+      },
+      {
+        "field": "resource_type",
+        "label": "Type"
+      },
+      {
+        "field": "related_url",
+        "label": "Related URL"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "source",
+        "label": "Source"
+      },
+      {
+        "field": "start_date",
+        "label": "Date"
+      },
+      {
+        "field": "tags",
+        "label": "Tags"
+      }
+    ]
   }
 }

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -205,5 +205,139 @@
         "direction": "desc"
       }
     ]
+  },
+  "displayedAttributes": {
+    "collection": [
+      {
+        "field": "size",
+        "label": "Size"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "date",
+        "label": "Date"
+      },
+      {
+        "field": "subject",
+        "label": "Subject"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "related_url",
+        "label": "Relation"
+      },
+      {
+        "field": "provenance",
+        "label": "Provenance"
+      },
+      {
+        "field": "belongs_to",
+        "label": "Is Part Of"
+      }
+    ],
+    "archive": [
+      {
+        "field": "identifier",
+        "label": "Identifier"
+      },
+      {
+        "field": "belongs_to",
+        "label": "Is Part Of"
+      },
+      {
+        "field": "bibliographic_citation",
+        "label": "Bibliographic citation"
+      },
+      {
+        "field": "contributor",
+        "label": "Contributor"
+      },
+      {
+        "field": "creator",
+        "label": "Creator"
+      },
+      {
+        "field": "custom_key",
+        "label": "Permanent Link"
+      },
+      {
+        "field": "format",
+        "label": "Format"
+      },
+      {
+        "field": "language",
+        "label": "Language"
+      },
+      {
+        "field": "location",
+        "label": "Location"
+      },
+      {
+        "field": "medium",
+        "label": "Medium"
+      },
+      {
+        "field": "resource_type",
+        "label": "Type"
+      },
+      {
+        "field": "related_url",
+        "label": "Relation"
+      },
+      {
+        "field": "provenance",
+        "label": "Provenance"
+      },
+      {
+        "field": "repository",
+        "label": "Repository"
+      },
+      {
+        "field": "reference",
+        "label": "References"
+      },
+      {
+        "field": "rights_holder",
+        "label": "Rights holder"
+      },
+      {
+        "field": "rights_statement",
+        "label": "Rights"
+      },
+      {
+        "field": "source",
+        "label": "Source"
+      },
+      {
+        "field": "start_date",
+        "label": "Date"
+      },
+      {
+        "field": "tags",
+        "label": "Subject"
+      }
+    ]
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2311) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
PR (https://github.com/VTUL/dlp-access/pull/172) for https://webapps.es.vt.edu/jira/browse/LIBTD-1982, which implements customizations for Collection and Archive metadata display.

# What does this Pull Request do? (:star:)
This PR adds Collection and Archive metadata display customizations into site config JSON files for IAWA, SWVA and default.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields