### PR TITLE
Description attribute for item list view

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -153,6 +153,10 @@
     ],
     "archive": [
       {
+        "field": "description",
+        "label": "Description"
+      },
+      {
         "field": "identifier",
         "label": "Identifier"
       },

--- a/configs/hokies.json
+++ b/configs/hokies.json
@@ -144,6 +144,10 @@
     ],
     "archive": [
       {
+        "field": "description",
+        "label": "Description"
+      },
+      {
         "field": "identifier",
         "label": "Identifier"
       },

--- a/configs/iawa.json
+++ b/configs/iawa.json
@@ -408,6 +408,10 @@
     ],
     "archive": [
       {
+        "field": "description",
+        "label": "Description"
+      },
+      {
         "field": "identifier",
         "label": "Identifier"
       },

--- a/configs/swva.json
+++ b/configs/swva.json
@@ -259,6 +259,10 @@
     ],
     "archive": [
       {
+        "field": "description",
+        "label": "Description"
+      },
+      {
         "field": "identifier",
         "label": "Identifier"
       },


### PR DESCRIPTION
What does this PR do:
Adds the description attribute to the list of displayed attributes since it it displayed in the item list view component for all libraries.

How to test:
Once my next PR for the dlp-access repo is submitted, this would allow the metadata elements in the item list view to display.

interested parties:
@yinlinchen 